### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/miisaac/940da45d-59f1-4ceb-b8b4-493dca28b115/002d8e53-6899-49a0-9025-2019fb1ace62/_apis/work/boardbadge/ec3fafef-68ed-48ad-82e1-843926e046ef)](https://dev.azure.com/miisaac/940da45d-59f1-4ceb-b8b4-493dca28b115/_boards/board/t/002d8e53-6899-49a0-9025-2019fb1ace62/Microsoft.EpicCategory)
 [![Build Status](https://dev.azure.com/miisaac/interro.us/_apis/build/status/mbuotidem.interro?branchName=master)](https://dev.azure.com/miisaac/interro.us/_build/latest?definitionId=1&branchName=master)
 
 # interro


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#42](https://dev.azure.com/miisaac/940da45d-59f1-4ceb-b8b4-493dca28b115/_workitems/edit/42). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.